### PR TITLE
検索キーの持ち方について #46

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,24 +103,9 @@
                     <legend>公立認可保育園</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="PubNinkaOpenTime" class="select">開園</label>
-                        <select id="PubNinkaOpenTime" class="filtersb">
-                            <option value="">開園</option>
-                            <!-- 2017-02 kakiki-upd
-                            <option value="7">7:00</option>
-                            -->
-                            <option value="7">7:00以前</option>
-                            <option value="8">8:00以前</option>
-                            <option value="9">9:00以前</option>
-                        </select>
+                        <select id="PubNinkaOpenTime" class="filtersb"></select>
                         <label for="PubNinkaCloseTime" class="select">終園</label>
-                        <select id="PubNinkaCloseTime" class="filtersb">
-                            <option value="">終園</option>
-                            <option value="18">18:00以降</option>
-                            <option value="19">19:00以降</option>
-                            <option value="20">20:00以降</option>
-                            <option value="22">22:00以降</option>
-                            <option value="24">00:00以降</option>
-                        </select>
+                        <select id="PubNinkaCloseTime" class="filtersb"></select>
                     <!--
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -140,24 +125,9 @@
                     <legend>私立認可保育園</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="PriNinkaOpenTime" class="select">開園</label>
-                        <select id="PriNinkaOpenTime" class="filtersb">
-                            <option value="">開園</option>
-                            <!-- 2017-02 kakiki-upd
-                            <option value="7">7:00</option>
-                            -->
-                            <option value="7">7:00以前</option>
-                            <option value="8">8:00以前</option>
-                            <option value="9">9:00以前</option>
-                        </select>
+                        <select id="PriNinkaOpenTime" class="filtersb openTime"></select>
                         <label for="PriNinkaCloseTime" class="select">終園</label>
-                        <select id="PriNinkaCloseTime" class="filtersb">
-                            <option value="">終園</option>
-                            <option value="18">18:00以降</option>
-                            <option value="19">19:00以降</option>
-                            <option value="20">20:00以降</option>
-                            <option value="22">22:00以降</option>
-                            <option value="24">00:00以降</option>
-                        </select>
+                        <select id="PriNinkaCloseTime" class="filtersb"></select>
                     <!--
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -177,24 +147,9 @@
                     <legend>横浜保育室</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="YhoikuOpenTime" class="select">開園</label>
-                        <select id="YhoikuOpenTime" class="filtersb">
-                            <option value="">開園</option>
-                            <!-- 2017-02 kakiki-upd
-                            <option value="7">7:00</option>
-                            -->
-                            <option value="7">7:00以前</option>
-                            <option value="8">8:00以前</option>
-                            <option value="9">9:00以前</option>
-                        </select>
+                        <select id="YhoikuOpenTime" class="filtersb"></select>
                         <label for="YhoikuCloseTime" class="select">終園</label>
-                        <select id="YhoikuCloseTime" class="filtersb">
-                            <option value="">終園</option>
-                            <option value="18">18:00以降</option>
-                            <option value="19">19:00以降</option>
-                            <option value="20">20:00以降</option>
-                            <option value="22">22:00以降</option>
-                            <option value="24">00:00以降</option>
-                        </select>
+                        <select id="YhoikuCloseTime" class="filtersb"></select>
                     <!--
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -215,27 +170,9 @@
                     <legend>認可外保育園</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="ninkagaiOpenTime" class="select">開園</label>
-                        <select id="ninkagaiOpenTime" class="filtersb">
-                            <option value="">開園</option>
-                            <!-- 2017-02 kakiki-upd
-                            <option value="7:00">7:00</option>
-                            <option value="7:30">7:30以前</option>
-                            <option value="7:45">7:45以前</option>
-                            <option value="8:00">8:00以前</option>
-                            -->
-                            <option value="7">7:00以前</option>
-                            <option value="8">8:00以前</option>
-                            <option value="9">9:00以前</option>
-                        </select>
+                        <select id="ninkagaiOpenTime" class="filtersb"></select>
                         <label for="ninkagaiCloseTime" class="select">終園</label>
-                        <select id="ninkagaiCloseTime" class="filtersb">
-                            <option value="">終園</option>
-                            <option value="18">18:00以降</option>
-                            <option value="19">19:00以降</option>
-                            <option value="20">20:00以降</option>
-                            <option value="22">22:00以降</option>
-                            <option value="24">00:00以降</option>
-                        </select>
+                        <select id="ninkagaiCloseTime" class="filtersb"></select>
                         <label for="ninkagai24H">24時間</label>
                         <input type="checkbox" id="ninkagai24H" class="filtercb">
                     </fieldset>
@@ -282,6 +219,7 @@
         <script src="js/facilityfilter.js" type="text/javascript"></script>
         <script src="js/papamamap.js" type="text/javascript"></script>
         <script src="js/index.js" type="text/javascript"></script>
+        <script src="js/index_smatsuda.js" type="text/javascript"></script>
         <div id="marker"></div>
         <div id="markerTitle"></div>
         <div id="center_marker"></div>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
         <link rel="stylesheet" href="css/jquery.mobile-1.4.4.css">
         <link rel="stylesheet" href="css/base.css" type="text/css">
         <link rel="stylesheet" href="css/icon-pack-custom.css">
-        <script>
+        <!-- <script>
             //Google Analytics アクセス解析用タグ
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -18,7 +18,7 @@
             })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
             ga('create', 'UA-93459242-1', 'auto');
             ga('send', 'pageview');
-        </script>
+        </script> -->
 
     </head>
     <body>

--- a/index.html
+++ b/index.html
@@ -106,6 +106,8 @@
                         <select id="PubNinkaOpenTime" class="filtersb"></select>
                         <label for="PubNinkaCloseTime" class="select">終園</label>
                         <select id="PubNinkaCloseTime" class="filtersb"></select>
+                        <label for="PubNinka24H">24時間</label>
+                        <input type="checkbox" id="PubNinka24H" class="filtercb">
                     <!--
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -128,6 +130,8 @@
                         <select id="PriNinkaOpenTime" class="filtersb openTime"></select>
                         <label for="PriNinkaCloseTime" class="select">終園</label>
                         <select id="PriNinkaCloseTime" class="filtersb"></select>
+                        <label for="PriNinka24H">24時間</label>
+                        <input type="checkbox" id="PriNinka24H" class="filtercb">
                     <!--
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -150,6 +154,8 @@
                         <select id="YhoikuOpenTime" class="filtersb"></select>
                         <label for="YhoikuCloseTime" class="select">終園</label>
                         <select id="YhoikuCloseTime" class="filtersb"></select>
+                        <label for="Yhoiku24H">24時間</label>
+                        <input type="checkbox" id="Yhoiku24H" class="filtercb">
                     <!--
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">

--- a/index.html
+++ b/index.html
@@ -196,6 +196,27 @@
                     <input type="checkbox" id="ninkagaiShomei" class="filtercb">
                     </fieldset>
                     -->
+                    <legend>幼稚園</legend>
+                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
+                        <label for="KindergartenOpenTime" class="select">開園</label>
+                        <select id="KindergartenOpenTime" class="filtersb"></select>
+                        <label for="KindergartenCloseTime" class="select">終園</label>
+                        <select id="KindergartenCloseTime" class="filtersb"></select>
+                        <label for="Kindergarten24H">24時間</label>
+                        <input type="checkbox" id="Kindergarten24H" class="filtercb">
+                        <label for="KindergartenIchijiHoiku">一時保育</label>
+                        <input type="checkbox" id="KindergartenIchijiHoiku" class="filtercb">
+                        <label for="KindergartenYakan">夜間</label>
+                        <input type="checkbox" id="KindergartenYakan" class="filtercb">
+                        <label for="KindergartenKyujitu">休日</label>
+                        <input type="checkbox" id="KindergartenKyujitu" class="filtercb">
+                        <label for="KindergartenEncho">延長保育</label>
+                        <input type="checkbox" id="KindergartenEncho" class="filtercb">
+                    </fieldset>
+                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
+                        <label for="KindergartenVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
+                        <input type="checkbox" id="KindergartenVacancy" class="filtercb">
+                    </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <a href="#" data-rel="back" id="filterApply" class="ui-btn ui-corner-all ui-btn-a ui-btn-icon-left ui-icon-check">条件適用</a>
                         <a href="#" id="filterReset" class="ui-btn ui-corner-all ui-btn-a ui-btn-icon-left ui-icon-delete">リセット</a>

--- a/index.html
+++ b/index.html
@@ -118,6 +118,8 @@
                         <input type="checkbox" id="PubNinkaYakan" class="filtercb">
                         <label for="PubNinkaKyujitu">休日</label>
                         <input type="checkbox" id="PubNinkaKyujitu" class="filtercb">
+                        <label for="PubNinkaEncho">延長保育</label>
+                        <input type="checkbox" id="PubNinkaEncho" class="filtercb">
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="PubNinkaVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
@@ -142,6 +144,8 @@
                         <input type="checkbox" id="PriNinkaYakan" class="filtercb">
                         <label for="PriNinkaKyujitu">休日</label>
                         <input type="checkbox" id="PriNinkaKyujitu" class="filtercb">
+                        <label for="PriNinkaEncho">延長保育</label>
+                        <input type="checkbox" id="PriNinkaEncho" class="filtercb">
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="PriNinkaVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
@@ -166,6 +170,8 @@
                         <input type="checkbox" id="YhoikuYakan" class="filtercb">
                         <label for="YhoikuKyujitu">休日</label>
                         <input type="checkbox" id="YhoikuKyujitu" class="filtercb">
+                        <label for="YhoikuEncho">延長保育</label>
+                        <input type="checkbox" id="YhoikuEncho" class="filtercb">
                     </fieldset>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="YhoikuVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
@@ -181,6 +187,8 @@
                         <select id="ninkagaiCloseTime" class="filtersb"></select>
                         <label for="ninkagai24H">24時間</label>
                         <input type="checkbox" id="ninkagai24H" class="filtercb">
+                        <label for="ninkagaiEncho">延長保育</label>
+                        <input type="checkbox" id="ninkagaiEncho" class="filtercb">
                     </fieldset>
                     <!-- //2017-02 kakiki-del
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">

--- a/js/facilityfilter.js
+++ b/js/facilityfilter.js
@@ -157,6 +157,17 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
         pubNinkaFeatures = pubNinkaFeatures.filter(filterfunc);
     }
 */
+
+    // 公立認可保育所：24時間
+    if(conditions['PubNinka24H']) {
+        filterfunc = function (item,idx) {
+            var h24 = item.properties['H24'] ? item.properties['H24'] : item.properties['H24'];
+            if(h24 === conditions['PubNinka24H']) {
+                return true;
+            }
+        };
+        pubNinkaFeatures = pubNinkaFeatures.filter(filterfunc);
+    }
     // 公立認可保育所：一時
     if(conditions['PubNinkaIchijiHoiku']) {
         filterfunc = function (item,idx) {
@@ -299,6 +310,17 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
         priNinkaFeatures = priNinkaFeatures.filter(filterfunc);
     }
 */
+
+    // 私立認可保育所：24時間
+    if(conditions['PriNinka24H']) {
+        filterfunc = function (item,idx) {
+            var h24 = item.properties['H24'] ? item.properties['H24'] : item.properties['H24'];
+            if(h24 === conditions['PriNinka24H']) {
+                return true;
+            }
+        };
+        priNinkaFeatures = priNinkaFeatures.filter(filterfunc);
+    }
     // 私立認可保育所：一時
     if(conditions['PriNinkaIchijiHoiku']) {
         filterfunc = function (item,idx) {
@@ -560,6 +582,17 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
         yhoikuFeatures = yhoikuFeatures.filter(filterfunc);
     }
 */
+
+    // 横浜保育室：24時間
+    if(conditions['Yhoiku24H']) {
+        filterfunc = function (item,idx) {
+            var h24 = item.properties['H24'] ? item.properties['H24'] : item.properties['H24'];
+            if(h24 === conditions['Yhoiku24H']) {
+                return true;
+            }
+        };
+        yhoikuFeatures = yhoikuFeatures.filter(filterfunc);
+    }
     // 横浜保育室：一時
     if(conditions['YhoikuIchijiHoiku']) {
         filterfunc = function (item,idx) {

--- a/js/facilityfilter.js
+++ b/js/facilityfilter.js
@@ -53,12 +53,12 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     /* 2017-02 @kakiki ins-end */
 
     // 幼稚園の検索元データを取得
-    var youchienFeatures = [];
+    var kindergartenFeatures = [];
     _features = nurseryFacilities.features.filter(function (item,idx) {
             var type = item.properties['種別'] ? item.properties['種別'] : item.properties['Type'];
             if(type == "幼稚園") return true;
         });
-    Array.prototype.push.apply(youchienFeatures, _features);
+    Array.prototype.push.apply(kindergartenFeatures, _features);
 
     // 小規模保育・事業所内の検索元データを取得
     // 未対応(2017-02現在)
@@ -682,7 +682,116 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     // ----------------------------------------------------------------------
     // 幼稚園向けフィルター
     // ----------------------------------------------------------------------
-    // まだ用意しない
+    // ----------------------------------------------------------------------
+    // 幼稚園：開園時間
+    if(conditions['KindergartenOpenTime']) {
+        filterfunc = function (item, idx) {
+            f = function (item,idx) {
+                var openHour = conditions['KindergartenOpenTime'].slice(0, conditions['KindergartenOpenTime'].indexOf(":"));
+                var openMin = Number(conditions['KindergartenOpenTime'].slice(-2));
+                var _open = new Date(2010, 0, 1, openHour, openMin, 0);
+                var open = item.properties['開園時間'] ? item.properties['開園時間'] : item.properties['Open'];
+                //各保育園の開園時間を変換
+                open = open.replace("：", ":");  //全角だったら半角に変更
+                var hour = open.slice(0, open.indexOf(":"));
+                var min = open.slice(-2);
+                var open_time = new Date(2010, 0, 1, hour, min, 0);
+                if(open !== "" && open_time <= _open) {
+                    return true;
+                }
+            };
+            return f(item,idx);
+        };
+        kindergartenFeatures = kindergartenFeatures.filter(filterfunc);
+    }
+    // 幼稚園：終園時間
+    if(conditions['KindergartenCloseTime']) {
+        filterfunc = function (item, idx) {
+            f = function (item,idx) {
+                var closeHour = conditions['KindergartenCloseTime'].slice(0, conditions['KindergartenCloseTime'].indexOf(":"));
+                var closeMin = Number(conditions['KindergartenCloseTime'].slice(-2));
+                var _close = new Date(2010, 0, 1, closeHour, closeMin, 0);
+                var close = item.properties['終園時間'] ? item.properties['終園時間'] : item.properties['Close'];
+                //各保育園の終園時間を変換
+                close = close.replace("：", ":");  //全角だったら半角に変更
+                var hour = close.slice(0, close.indexOf(":"));
+                if(hour !== "" && hour <= 12) {hour = hour + 24};  //終園時間が24時過ぎの場合翌日扱い
+                var min = close.slice(-2);
+                var close_time = new Date(2010, 0, 1, hour, min, 0);
+                if(close_time >= _close) {
+                      return true;
+                  }
+            };
+            return f(item,idx);
+        };
+
+        kindergartenFeatures = kindergartenFeatures.filter(filterfunc);
+    }
+    // 幼稚園：24時間
+    if(conditions['Kindergarten24H']) {
+        filterfunc = function (item,idx) {
+            var h24 = item.properties['H24'] ? item.properties['H24'] : item.properties['H24'];
+            if(h24 === conditions['Kindergarten24H']) {
+                return true;
+            }
+        };
+        kindergartenFeatures = kindergartenFeatures.filter(filterfunc);
+    }
+    // 幼稚園：一時
+    if(conditions['KindergartenIchijiHoiku']) {
+        filterfunc = function (item,idx) {
+            var temp = item.properties['一時'] ? item.properties['一時'] : item.properties['Temp'];
+//            if(temp !== null) { //2017-02 kakiki-upd
+            if(temp === conditions['KindergartenIchijiHoiku']) {
+                return true;
+            }
+        };
+        kindergartenFeatures = kindergartenFeatures.filter(filterfunc);
+    }
+    // 幼稚園：夜間
+    if(conditions['KindergartenYakan']) {
+        filterfunc = function (item,idx) {
+            var night = item.properties['夜間'] ? item.properties['夜間'] : item.properties['Night'];
+//            if(night !== null) { //2017-02 kakiki-upd
+            if(night === conditions['KindergartenYakan']) {
+                return true;
+            }
+        };
+        kindergartenFeatures = kindergartenFeatures.filter(filterfunc);
+    }
+    // 幼稚園：休日
+    if(conditions['KindergartenKyujitu']) {
+        filterfunc = function (item,idx) {
+            var holiday = item.properties['休日'] ? item.properties['休日'] : item.properties['Holiday'];
+//            if(holiday !== null) { //2017-02 kakiki-upd
+            if(holiday === conditions['KindergartenKyujitu']) {
+                return true;
+            }
+        };
+        kindergartenFeatures = kindergartenFeatures.filter(filterfunc);
+    }
+    // 幼稚園：延長保育
+    if(conditions['KindergartenEncho']) {
+        filterfunc = function (item,idx) {
+            var extra = item.properties['延長保育'] ? item.properties['延長保育'] : item.properties['Extra'];
+            if(extra === conditions['KindergartenEncho']) {
+                return true;
+            }
+        };
+        kindergartenFeatures = kindergartenFeatures.filter(filterfunc);
+    }
+    // 幼稚園：空きあり
+    if(conditions['KindergartenVacancy']) {
+        filterfunc = function (item,idx) {
+            var vacancy = item.properties['Vacancy'] ? item.properties['Vacancy'] : item.properties['Vacancy'];
+//            if(vacancy !== null) { //2017-02 kakiki-upd
+            if(vacancy === conditions['KindergartenVacancy']) {
+                return true;
+            }
+        };
+        kindergartenFeatures = kindergartenFeatures.filter(filterfunc);
+    }
+
 
     // 戻り値の作成
     var features = [];
@@ -690,7 +799,7 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     Array.prototype.push.apply(features, priNinkaFeatures);
     Array.prototype.push.apply(features, pubNinkaFeatures);
     Array.prototype.push.apply(features, ninkagaiFeatures);
-    Array.prototype.push.apply(features, youchienFeatures);
+    Array.prototype.push.apply(features, kindergartenFeatures);
     Array.prototype.push.apply(features, yhoikuFeatures);   //2017-02 kakiki-ins
     // console.log("getFilteredFeaturesGeoJson: return value: ", features.length);
     newGeoJson.features = features;

--- a/js/facilityfilter.js
+++ b/js/facilityfilter.js
@@ -70,7 +70,9 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     if(conditions['PubNinkaOpenTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                var _open = new Date(2010, 0, 1, conditions['PubNinkaOpenTime'], 0, 0);
+                var openHour = conditions['PubNinkaOpenTime'].slice(0, conditions['PubNinkaOpenTime'].indexOf(":"));
+                var openMin = Number(conditions['PubNinkaOpenTime'].slice(-2));
+                var _open = new Date(2010, 0, 1, openHour, openMin, 0);
                 var open = item.properties['開園時間'] ? item.properties['開園時間'] : item.properties['Open'];
                 //各保育園の開園時間を変換
                 open = open.replace("：", ":");  //全角だったら半角に変更
@@ -89,7 +91,9 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     if(conditions['PubNinkaCloseTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                var _close = new Date(2010, 0, 1, conditions['PubNinkaCloseTime'], 0, 0);
+                var closeHour = conditions['PubNinkaCloseTime'].slice(0, conditions['PubNinkaCloseTime'].indexOf(":"));
+                var closeMin = Number(conditions['PubNinkaCloseTime'].slice(-2));
+                var _close = new Date(2010, 0, 1, closeHour, closeMin, 0);
                 var close = item.properties['終園時間'] ? item.properties['終園時間'] : item.properties['Close'];
                 //各保育園の終園時間を変換
                 close = close.replace("：", ":");  //全角だったら半角に変更
@@ -206,7 +210,9 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     if(conditions['PriNinkaOpenTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                var _open = new Date(2010, 0, 1, conditions['PriNinkaOpenTime'], 0, 0);
+                var openHour = conditions['PriNinkaOpenTime'].slice(0, conditions['PriNinkaOpenTime'].indexOf(":"));
+                var openMin = Number(conditions['PriNinkaOpenTime'].slice(-2));
+                var _open = new Date(2010, 0, 1, openHour, openMin, 0);
                 var open = item.properties['開園時間'] ? item.properties['開園時間'] : item.properties['Open'];
                 //各保育園の開園時間を変換
                 open = open.replace("：", ":");  //全角だったら半角に変更
@@ -225,7 +231,9 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     if(conditions['PriNinkaCloseTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                var _close = new Date(2010, 0, 1, conditions['PriNinkaCloseTime'], 0, 0);
+                var closeHour = conditions['PriNinkaCloseTime'].slice(0, conditions['PriNinkaCloseTime'].indexOf(":"));
+                var closeMin = Number(conditions['PriNinkaCloseTime'].slice(-2));
+                var _close = new Date(2010, 0, 1, closeHour, closeMin, 0);
                 var close = item.properties['終園時間'] ? item.properties['終園時間'] : item.properties['Close'];
                 //各保育園の終園時間を変換
                 close = close.replace("：", ":");  //全角だったら半角に変更
@@ -344,7 +352,9 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     if(conditions['ninkagaiOpenTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                var _open = new Date(2010, 0, 1, conditions['ninkagaiOpenTime'], 0, 0);
+                var openHour = conditions['ninkagaiOpenTime'].slice(0, conditions['ninkagaiOpenTime'].indexOf(":"));
+                var openMin = Number(conditions['ninkagaiOpenTime'].slice(-2));
+                var _open = new Date(2010, 0, 1, openHour, openMin, 0);
                 var open = item.properties['開園時間'] ? item.properties['開園時間'] : item.properties['Open'];
                 //各保育園の開園時間を変換
                 open = open.replace("：", ":");  //全角だったら半角に変更
@@ -363,7 +373,9 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     if(conditions['ninkagaiCloseTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                var _close = new Date(2010, 0, 1, conditions['ninkagaiCloseTime'], 0, 0);
+                var closeHour = conditions['ninkagaiCloseTime'].slice(0, conditions['ninkagaiCloseTime'].indexOf(":"));
+                var closeMin = Number(conditions['ninkagaiCloseTime'].slice(-2));
+                var _close = new Date(2010, 0, 1, closeHour, closeMin, 0);
                 var close = item.properties['終園時間'] ? item.properties['終園時間'] : item.properties['Close'];
                 //各保育園の終園時間を変換
                 close = close.replace("：", ":");  //全角だったら半角に変更
@@ -461,7 +473,9 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     if(conditions['YhoikuOpenTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                var _open = new Date(2010, 0, 1, conditions['YhoikuOpenTime'], 0, 0);
+                var openHour = conditions['YhoikuOpenTime'].slice(0, conditions['YhoikuOpenTime'].indexOf(":"));
+                var openMin = Number(conditions['YhoikuOpenTime'].slice(-2));
+                var _open = new Date(2010, 0, 1, openHour, openMin, 0);
                 var open = item.properties['開園時間'] ? item.properties['開園時間'] : item.properties['Open'];
                 //各保育園の開園時間を変換
                 open = open.replace("：", ":");  //全角だったら半角に変更
@@ -480,7 +494,9 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
     if(conditions['YhoikuCloseTime']) {
         filterfunc = function (item, idx) {
             f = function (item,idx) {
-                var _close = new Date(2010, 0, 1, conditions['YhoikuCloseTime'], 0, 0);
+                var closeHour = conditions['YhoikuCloseTime'].slice(0, conditions['YhoikuCloseTime'].indexOf(":"));
+                var closeMin = Number(conditions['YhoikuCloseTime'].slice(-2));
+                var _close = new Date(2010, 0, 1, closeHour, closeMin, 0);
                 var close = item.properties['終園時間'] ? item.properties['終園時間'] : item.properties['Close'];
                 //各保育園の終園時間を変換
                 close = close.replace("：", ":");  //全角だったら半角に変更

--- a/js/facilityfilter.js
+++ b/js/facilityfilter.js
@@ -201,6 +201,16 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
         };
         pubNinkaFeatures = pubNinkaFeatures.filter(filterfunc);
     }
+    // 公立認可保育所：延長保育
+    if(conditions['PubNinkaEncho']) {
+        filterfunc = function (item,idx) {
+            var extra = item.properties['延長保育'] ? item.properties['延長保育'] : item.properties['Extra'];
+            if(extra === conditions['PubNinkaEncho']) {
+                return true;
+            }
+        };
+        pubNinkaFeatures = pubNinkaFeatures.filter(filterfunc);
+    }
     // 公立認可保育所：空きあり
     if(conditions['PubNinkaVacancy']) {
         filterfunc = function (item,idx) {
@@ -354,6 +364,16 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
         };
         priNinkaFeatures = priNinkaFeatures.filter(filterfunc);
     }
+    // 私立認可保育所：延長保育
+    if(conditions['PriNinkaEncho']) {
+        filterfunc = function (item,idx) {
+            var extra = item.properties['延長保育'] ? item.properties['延長保育'] : item.properties['Extra'];
+            if(extra === conditions['PriNinkaEncho']) {
+                return true;
+            }
+        };
+        priNinkaFeatures = priNinkaFeatures.filter(filterfunc);
+    }
     // 私立認可保育所：空きあり
     if(conditions['PriNinkaVacancy']) {
         filterfunc = function (item,idx) {
@@ -469,6 +489,16 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
             var h24 = item.properties['H24'] ? item.properties['H24'] : item.properties['H24'];
 //            if(h24 !== null) { //2017-02 kakiki-upd
             if(h24 === conditions['ninkagai24H']) {
+                return true;
+            }
+        };
+        ninkagaiFeatures = ninkagaiFeatures.filter(filterfunc);
+    }
+    // 認可外保育所：延長保育
+    if(conditions['ninkagaiEncho']) {
+        filterfunc = function (item,idx) {
+            var extra = item.properties['延長保育'] ? item.properties['延長保育'] : item.properties['Extra'];
+            if(extra === conditions['ninkagaiEncho']) {
                 return true;
             }
         };
@@ -621,6 +651,16 @@ FacilityFilter.prototype.getFilteredFeaturesGeoJson = function (conditions, nurs
             var holiday = item.properties['休日'] ? item.properties['休日'] : item.properties['Holiday'];
 //            if(holiday !== null) { //2017-02 kakiki-upd
             if(holiday === conditions['YhoikuKyujitu']) {
+                return true;
+            }
+        };
+        yhoikuFeatures = yhoikuFeatures.filter(filterfunc);
+    }
+    // 横浜保育室：延長保育
+    if(conditions['YhoikuEncho']) {
+        filterfunc = function (item,idx) {
+            var extra = item.properties['延長保育'] ? item.properties['延長保育'] : item.properties['Extra'];
+            if(extra === conditions['YhoikuEncho']) {
                 return true;
             }
         };

--- a/js/index.js
+++ b/js/index.js
@@ -364,6 +364,10 @@ $('#mainPage').on('pageshow', function() {
 			conditions['PubNinkaKyujitu'] = "Y"; //1;
 			pubNinka = true;
 		}
+		if($('#PubNinkaEncho').prop('checked')) {
+			conditions['PubNinkaEncho'] = "Y"; //1;
+			pubNinka = true;
+		}
 		if($('#PubNinkaVacancy').prop('checked')) {
 			conditions['PubNinkaVacancy'] = "Y"; //1;
 			pubNinka = true;
@@ -394,6 +398,10 @@ $('#mainPage').on('pageshow', function() {
 			conditions['PriNinkaKyujitu'] = "Y"; //1;
 			priNinka = true;
 		}
+		if($('#PriNinkaEncho').prop('checked')) {
+			conditions['PriNinkaEncho'] = "Y"; //1;
+			priNinka = true;
+		}
 		if($('#PriNinkaVacancy').prop('checked')) {
 			conditions['PriNinkaVacancy'] = "Y"; //1;
 			priNinka = true;
@@ -411,6 +419,10 @@ $('#mainPage').on('pageshow', function() {
 		}
 		if($('#ninkagai24H').prop('checked')) {
 			conditions['ninkagai24H'] = "Y"; //1;
+			ninkagai = true;
+		}
+		if($('#ninkagaiEncho').prop('checked')) {
+			conditions['ninkagaiEncho'] = "Y"; //1;
 			ninkagai = true;
 		}
 		if($('#ninkagaiShomei').prop('checked')) {
@@ -441,6 +453,10 @@ $('#mainPage').on('pageshow', function() {
 		}
 		if($('#YhoikuKyujitu').prop('checked')) {
 			conditions['YhoikuKyujitu'] = "Y"; //1;
+			yhoiku = true;
+		}
+		if($('#YhoikuEncho').prop('checked')) {
+			conditions['YhoikuEncho'] = "Y"; //1;
 			yhoiku = true;
 		}
 		if($('#YhoikuVacancy').prop('checked')) {

--- a/js/index.js
+++ b/js/index.js
@@ -467,6 +467,39 @@ $('#mainPage').on('pageshow', function() {
 		// 小規模・事業所内保育事業：未対応
 
 		// 幼稚園
+		if($('#KindergartenOpenTime option:selected').val() !== "") {
+			conditions['KindergartenOpenTime'] = $('#KindergartenOpenTime option:selected').val();
+			kindergarten = true;
+		}
+		if($('#KindergartenCloseTime option:selected').val() !== "") {
+			conditions['KindergartenCloseTime'] = $('#KindergartenCloseTime option:selected').val();
+			kindergarten = true;
+		}
+		if($('#Kindergarten24H').prop('checked')) {
+			conditions['Kindergarten24H'] = "Y"; //1;
+			kindergarten = true;
+		}
+		if($('#KindergartenIchijiHoiku').prop('checked')) {
+			conditions['KindergartenIchijiHoiku'] = "Y"; //1;
+			kindergarten = true;
+		}
+		if($('#KindergartenYakan').prop('checked')) {
+			conditions['KindergartenYakan'] = "Y"; //1;
+			kindergarten = true;
+		}
+		if($('#KindergartenKyujitu').prop('checked')) {
+			conditions['KindergartenKyujitu'] = "Y"; //1;
+			kindergarten = true;
+		}
+		if($('#KindergartenEncho').prop('checked')) {
+			conditions['KindergartenEncho'] = "Y"; //1;
+			kindergarten = true;
+		}
+		if($('#KindergartenVacancy').prop('checked')) {
+			conditions['KindergartenVacancy'] = "Y"; //1;
+			kindergarten = true;
+		}
+
 
 		// フィルター適用時
 		if(Object.keys(conditions).length > 0) {

--- a/js/index.js
+++ b/js/index.js
@@ -332,6 +332,7 @@ $('#mainPage').on('pageshow', function() {
 
     // 検索フィルターを有効にする
 	$('#filterApply').click(function(evt){
+
 		// 条件作成処理
 		conditions = [];
 		//ninka = ninkagai = yhoiku = kindergarten = jigyosho = false;		//2017-02 @kakiki upd
@@ -345,6 +346,10 @@ $('#mainPage').on('pageshow', function() {
 		}
 		if($('#PubNinkaCloseTime option:selected').val() !== "") {
 			conditions['PubNinkaCloseTime'] = $('#PubNinkaCloseTime option:selected').val();
+			pubNinka = true;
+		}
+		if($('#PubNinka24H').prop('checked')) {
+			conditions['PubNinka24H'] = "Y"; //1;
 			pubNinka = true;
 		}
 		if($('#PubNinkaIchijiHoiku').prop('checked')) {
@@ -371,6 +376,10 @@ $('#mainPage').on('pageshow', function() {
 		}
 		if($('#PriNinkaCloseTime option:selected').val() !== "") {
 			conditions['PriNinkaCloseTime'] = $('#PriNinkaCloseTime option:selected').val();
+			priNinka = true;
+		}
+		if($('#PriNinka24H').prop('checked')) {
+			conditions['PriNinka24H'] = "Y"; //1;
 			priNinka = true;
 		}
 		if($('#PriNinkaIchijiHoiku').prop('checked')) {
@@ -416,6 +425,10 @@ $('#mainPage').on('pageshow', function() {
 		}
 		if($('#YhoikuCloseTime option:selected').val() !== "") {
 			conditions['YhoikuCloseTime'] = $('#YhoikuCloseTime option:selected').val();
+			yhoiku = true;
+		}
+		if($('#Yhoiku24H').prop('checked')) {
+			conditions['Yhoiku24H'] = "Y"; //1;
 			yhoiku = true;
 		}
 		if($('#YhoikuIchijiHoiku').prop('checked')) {

--- a/js/index_smatsuda.js
+++ b/js/index_smatsuda.js
@@ -1,0 +1,39 @@
+// select options
+
+// 検索 OpenTime
+var openTime = function () {
+	var startHour = 7;
+	var endHour = 8;
+	var options = '<option value="">開園</option>';
+	for(var hour = startHour ; hour <=endHour; hour++){
+		  options += '<option value="' + hour + ':00">' + hour + ':00以前</option>';
+		  options += '<option value="' + hour + ':15">' + hour + ':15以前</option>';
+		  options += '<option value="' + hour + ':45">' + hour + ':45以前</option>';
+	}
+	options += '<option value="9:00">9:00以前</option>';
+
+	document.getElementById("PubNinkaOpenTime").innerHTML = options;
+	document.getElementById("PriNinkaOpenTime").innerHTML = options;
+	document.getElementById("YhoikuOpenTime").innerHTML = options;
+	document.getElementById("ninkagaiOpenTime").innerHTML = options;
+}
+openTime();
+
+// 検索 OpenTime
+var CloseTime = function () {
+	var startHour = 18;
+	var endHour = 21;
+	var options = '<option value="">終園</option>';
+	for(var hour = startHour ; hour <=endHour; hour++){
+		  options += '<option value="' + hour + ':00">' + hour + ':00以降</option>';
+		  options += '<option value="' + hour + ':30">' + hour + ':30以降</option>';
+	}
+	options += '<option value="22:00">22:00以前</option>';
+	options += '<option value="00:00">00:00以前</option>';
+
+	document.getElementById("PubNinkaCloseTime").innerHTML = options;
+	document.getElementById("PriNinkaCloseTime").innerHTML = options;
+	document.getElementById("YhoikuCloseTime").innerHTML = options;
+	document.getElementById("ninkagaiCloseTime").innerHTML = options;
+}
+CloseTime();

--- a/js/index_smatsuda.js
+++ b/js/index_smatsuda.js
@@ -16,6 +16,7 @@ var openTime = function () {
 	document.getElementById("PriNinkaOpenTime").innerHTML = options;
 	document.getElementById("YhoikuOpenTime").innerHTML = options;
 	document.getElementById("ninkagaiOpenTime").innerHTML = options;
+	document.getElementById("KindergartenOpenTime").innerHTML = options;
 }
 openTime();
 
@@ -35,5 +36,6 @@ var CloseTime = function () {
 	document.getElementById("PriNinkaCloseTime").innerHTML = options;
 	document.getElementById("YhoikuCloseTime").innerHTML = options;
 	document.getElementById("ninkagaiCloseTime").innerHTML = options;
+	document.getElementById("KindergartenCloseTime").innerHTML = options;
 }
 CloseTime();

--- a/js/papamamap.js
+++ b/js/papamamap.js
@@ -400,6 +400,7 @@ Papamamap.prototype.getPopupContent = function(feature)
     var holiday = feature.get('休日') ? feature.get('休日') : feature.get('Holiday');
     var night   = feature.get('夜間') ? feature.get('夜間') : feature.get('Night');
     var h24     = feature.get('H24') ? feature.get('H24') : feature.get('H24');
+    var extra     = feature.get('延長保育') ? feature.get('延長保育') : feature.get('Extra');
 
     if( !isUndefined(temp) || !isUndefined(holiday) || !isUndefined(night) || !isUndefined(h24)) {
         content += '<tr>';
@@ -416,6 +417,9 @@ Papamamap.prototype.getPopupContent = function(feature)
         }
         if (formatNull(h24) !== null) {
             content += '24時間 ';
+        }
+        if (formatNull(extra) !== null) {
+            content += '延長保育 ';
         }
         content += '</td>';
         content += '</tr>';
@@ -457,6 +461,13 @@ Papamamap.prototype.getPopupContent = function(feature)
         content += '<tr>';
         content += '<th>TEL</th>';
         content += '<td>' + tel + '</td>';
+        content += '</tr>';
+    }
+    var fax = feature.get('FAX') ? feature.get('FAX') : feature.get('FAX');
+    if (!isUndefined(fax)) {
+        content += '<tr>';
+        content += '<th>FAX</th>';
+        content += '<td>' + fax + '</td>';
         content += '</tr>';
     }
     var add1 = feature.get('住所１') ? feature.get('住所１') : feature.get('Add1');


### PR DESCRIPTION
詳細と対応の相談があります。

// 開園と終園時間について
-> 開園7:00から9:00までの間を15分刻みにしてます。
-> 終園18:00から22:00までを30分刻みで飛んで0:00です。
[相談]
-> 終園時間の22:00の次に0:00と飛ぶのはもともとそうなっていたのでそのままにしました。
　　この区間も30分刻みにするか、また0:00まで必要でしょうか？
-> 15分、30分刻みにするとselectのoptionが長くなるので、
　　１つずつ記述するのが手間だったのもあり、js/inde_smatsuda.jsで記述しています。
　　index.jsに記述してもよかったのですが、基本的にindex.jsはolのイベントの定義なので、
　　作法などがあるのか未確認だったので別ファイルとしました。
　　index.jsのお尻に記述してよいものでしょうか。
　　それとも、そもそもhtmlでべた書きしたほうが直感的でいいですか？
　　※私はhtmlべた書きは記述が長いのと後の修正などで手間かと思います。

// 公立認可、私立認可、横浜保育室に24時間の絞り込みを追加
-> 元データで実際に24HがYとなってるのは私立認可保育所に１つだけですね。

// 公立認可、私立認可、横浜保育室、認可外に延長保育を追加

// アイコン選択時のポップアップの表示内容について
-> 上記追加を受けて延長保育を追加しました。
-> またもとデータでFAXの記入が結構ありましたのでついでに追加しました。
　　※本日、江口さんと話したところ、いまだにFAXのやりとりは結構あるとの話でしたし。

// 幼稚園の追加
-> 検索絞り込みでこれまでなかった幼稚園を追加しました。
　 検索項目はは認可外を除いて公立、私立、横浜、幼稚園ですべて同じになります。

[相談]
-> 検索項目はすべて同じでいいでしょうか？(認可外も同じに修正する)
　　それともそれぞれ個別にカスタマイズする
　　個人的には同じにしたほうが管理は楽だとは思いますが、
-> また未追加のものでイシューで言及されている小規模・事業所内保育事業と
　　私が元データを確認したところ、乳幼児一時預かり事業というのもありました。
　　これらも追加したほうがいいでしょうか？　
　　※乳幼児一時預かり事業はレイヤー自体ないですね。