### PR TITLE
アクセス解析の詳細化 #56

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -455,6 +455,13 @@ $('#mainPage').on('pageshow', function() {
 		// レイヤー表示状態によって施設の表示を切り替える
 		//updateLayerStatus({ninka: ninka, ninkagai: ninkagai, yhoiku: yhoiku, kindergarten: kindergarten, jigyosho: jigyosho});  //2017-02 @kakiki upd
 		updateLayerStatus({pubNinka: pubNinka, priNinka: priNinka, ninkagai: ninkagai, yhoiku: yhoiku, kindergarten: kindergarten, jigyosho: jigyosho});
+
+		// ga('send', 'event', 'カテゴリ', 'アクション', 'ラベル', '値', { nonInteraction: 真偽値 } )
+		// *nonInteraction: trueはイベントが発生しても直帰率に影響せず、falseはイベントの呼び出しで直帰とみなされなくなる
+		ga('send', 'event', 'filter', 'click', this.id);
+		// 本イベントを直帰率へ反映させたくない場合は以下を使用すること。
+		// ga('send', 'event', 'filter', 'click', this.id, , { nonInteraction: true });
+		
 	});
 
 	// 絞込条件のリセット


### PR DESCRIPTION
検索の条件適用クリックでGoogleAnalyticsのイベントトラッキングの追加です。
GAのアカウントが不明なので集計に反映されてるかは見えない？ですが、クリック時にちゃんとhttps://www.google-analytics.com/collectへトラフィックが発生してることは確認済みです。

index.jsに追記してます。clickイベントはjqueryで実装されてますので、index.html側でonclickで記述するとたぶんjquery側が動かなくなると思います。

[確認]
フォーマットは以下の通りで、カテゴリ以降の任意の設定は想定されてるものがあれば変更可能です。
またnonInteractionは直帰率に影響します。（指定なしでfalse:イベントの呼び出しで直帰とみなされなくなる）trueに変更が必要か念のため確認ください。

ga('send', 'event', 'カテゴリ', 'アクション', 'ラベル', '値', { nonInteraction: 真偽値 } )
ga('send', 'event', 'filter', 'click', this.id);

また他にもトラッキングしたい箇所があれば任意の設定部分を多少変えて追加可能です。