### PR TITLE
マップロゴとメニューバーをmap上に移し、ブラウザサイズによってレスポンシブ配置されるよう修正

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -24,40 +24,127 @@
 	text-shadow: black 0.1em 0.1em 0.2em;
 }
 
-#lblPriNinka.ui-checkbox-on {
-	background-color: #6EE100;
+#nav1-btn-div {
+	position: fixed;
+	top:0; right:20px;
+	padding: 0;
+	margin: 0;
+}
+
+#nav1 {
+	position: fixed;
+	top:0; left: 50px;
+}
+
+#map-logo {
+	position:fixed;
+	bottom:0;
+	width: 206px;
+	padding-left: 5px;
+	/* text-shadow: white 2px 2px 0px, white -2px 2px 0px,	white 2px -2px 0px, white -2px -2px 0px; */
+}
+
+#nav1-btn {
+	background-color: white;
+}
+#nav1-btn:hover {
+	background-color: #e0e0e0;
+}
+
+#nav1-btn, #lblPubNinka, #lblPriNinka, #lblNinkagai, #lblYhoiku, #lblJigyosho, #lblKindergarten, #lblDisability, #lblElementarySchool, #lblMiddleSchool,
+#btnFilter, #changeBaseMap-button, #moveTo-button, #changeCircleRadius-button, #btnHelp {
+	border: groove white;
+	border-radius: 5px 5px 5px 5px / 5px 5px 5px 5px;
 }
 
 #lblPubNinka.ui-checkbox-on {
 	background-color: #44AA00;
 }
+#lblPubNinka.ui-checkbox-off {
+	background-color: rgba(240,240,240,0.8);
+}
+#lblPubNinka:hover {
+	color: lightblue;
+}
+
+#lblPriNinka.ui-checkbox-on {
+	background-color: #6EE100;
+}
+#lblPriNinka.ui-checkbox-off {
+	background-color: rgba(240,240,240,0.8);
+}
+#lblPriNinka:hover {
+	color: lightblue;
+}
 
 #lblNinkagai.ui-checkbox-on {
 	background-color: #0362A0;
+}
+#lblNinkagai.ui-checkbox-off {
+	background-color: rgba(240,240,240,0.8);
+}
+#lblNinkagai:hover {
+	color: lightblue;
 }
 
 #lblYhoiku.ui-checkbox-on {
 	background-color: #0488EE;
 }
+#lblYhoiku.ui-checkbox-off {
+	background-color: rgba(240,240,240,0.8);
+}
+#lblYhoiku:hover {
+	color: lightblue;
+}
 
 #lblJigyosho.ui-checkbox-on {
 	background-color: #6DBA9C;
+}
+#lblJigyosho.ui-checkbox-off {
+	background-color: rgba(240,240,240,0.8);
+}
+#lblJigyosho:hover {
+	color: lightblue;
 }
 
 #lblKindergarten.ui-checkbox-on {
 	background-color: #FF5C24;
 }
+#lblKindergarten.ui-checkbox-off {
+	background-color: rgba(240,240,240,0.8);
+}
+#lblKindergarten:hover {
+	color: lightblue;
+}
 
 #lblDisability.ui-checkbox-on {
 	background-color: #f78cb7;
+}
+#lblDisability.ui-checkbox-off {
+	background-color: rgba(240,240,240,0.8);
+}
+#lblDisability:hover {
+	color: lightblue;
+}
+
+#lblElementarySchool.ui-checkbox-on {
+	background-color: #1BA466;
+}
+#lblElementarySchool.ui-checkbox-off {
+	background-color: rgba(240,240,240,0.8);
+}
+#lblElementarySchool:hover {
+	color: lightblue;
 }
 
 #lblMiddleSchool.ui-checkbox-on {
 	background-color: #7379AE;
 }
-
-#lblElementarySchool.ui-checkbox-on {
-	background-color: #1BA466;
+#lblMiddleSchool.ui-checkbox-off {
+	background-color: rgba(240,240,240,0.8);
+}
+#lblMiddleSchool:hover {
+	color: lightblue;
 }
 
 .ol-popup {
@@ -166,6 +253,7 @@ h3 {
 
 legend {
 	margin-bottom: 0;
+	font-size: medium;
 }
 
 /* ToDo: 検索ボタンの修正&対応が終わるまで無効化(btn-disabled) */

--- a/index.html
+++ b/index.html
@@ -24,9 +24,19 @@
     <body>
         <div data-role="page" id="mainPage">
             <div role="main" class="ui-content">
-            <div id="nav">
+              <div id="map" class="map">
+              </div>
+              <div id="nav1-btn-div">
+                <button type="button" id="nav1-btn" data-mini="true">
+                    <img src="css/images/icons-svg/bars-black.svg" alt="menu">
+                </button>
+              </div>
+            <div>
                 <fieldset id="nav1" data-role="controlgroup" data-type="horizontal" data-mini="true">
-                    <h3><font size="3"> Codefor港北</font> 保育園/幼稚園マップ</h3>
+                <ul style="padding-left:0; margin-left:0">
+                  <li class="nav1-li" style="display: inline-block;">
+                    <!-- <h3><font size="3"> Codefor港北</font> 保育園/幼稚園マップ</h3> -->
+
                     <label for="cbPubNinka" id="lblPubNinka">公立認可</label>
                     <input type="checkbox" name="cbPubNinka" id="cbPubNinka" checked="checked">
 
@@ -42,34 +52,41 @@
                     <label for="cbNinkagai" id="lblNinkagai">認可外</label>
                     <input type="checkbox" name="cbNinkagai" id="cbNinkagai" checked="checked">
 
-                    <label for="cbKindergarten" id="lblKindergarten">幼</label>
-                    <input type="checkbox" name="cbKindergarten" id="cbKindergarten" checked="checked">
-
                     <label for="cbDisability" id="lblDisability">児童発達支援</label>
                     <input type="checkbox" name="cbDisability" id="cbDisability" checked="checked">
+
+                    <label for="cbKindergarten" id="lblKindergarten">幼</label>
+                    <input type="checkbox" name="cbKindergarten" id="cbKindergarten" checked="checked">
 
                     <label for="cbElementarySchool" id="lblElementarySchool">小</label>
                     <input type="checkbox" name="cbElementarySchool" id="cbElementarySchool">
 
                     <label for="cbMiddleSchool" id="lblMiddleSchool">中</label>
                     <input type="checkbox" name="cbMiddleSchool" id="cbMiddleSchool">
+                  </li>
 
                     <!-- ToDo: 検索ボタンの修正&対応が終わるまで無効化 (btn-disabled) -->
                     <!-- 2017/02/25 kakiki-upd 検索機能確認の為ボタンを有効化 -->
                     <!--                    <a id="btnFilter" href="#filterdialog" data-rel="popup" data-position-to="window" class="btn-disabled ui-btn ui-corner-all ui-btn-a ui-icon-filter ui-btn-icon-right ui-icon-checkv">検索</a>                    -->
-                    <a id="btnFilter" href="#filterdialog" data-rel="popup" data-position-to="window" class="ui-btn ui-corner-all ui-btn-a ui-icon-filter ui-btn-icon-right ui-icon-check">検索</a>
+                  <li class="nav1-li" style="display: inline-block;">
+                    <a id="btnFilter" href="#filterdialog" data-rel="popup" data-position-to="window"
+                       class="ui-btn ui-corner-all ui-btn-a ui-icon-filter ui-btn-icon-right ui-icon-check">
+                       検索
+                    </a>
 
-                    <label for="changeBaseMap">背景</label>
-                    <select id="changeBaseMap" data-mini="true">
+                    <!-- <label for="changeBaseMap" class="ui-hidden-accessible">背景</label> -->
+                    <select id="changeBaseMap" >
+                      <!-- <select id="changeBaseMap" data-mini="true"> -->
                         <option>背景</option>
                     </select>
 
-                    <label for="moveTo">最寄駅</label>
-                    <select id="moveTo" data-mini="true">
+                    <!-- <label for="moveTo" class="ui-hidden-accessible">最寄駅</label> -->
+                    <select id="moveTo">
+                      <!-- <select id="moveTo" data-mini="true"> -->
                         <option>最寄駅</option>
                     </select>
 
-                    <label id="lblDisplayCircle" for="cbDisplayCircle" class="ui-btn-icon-notext">距離円<span class="ui-icon-bullseye ui-btn-icon-notext"></span></label>
+                    <!-- <label id="lblDisplayCircle" for="cbDisplayCircle" class="ui-btn-icon-notext">距離円<span class="ui-icon-bullseye ui-btn-icon-notext"></span></label> -->
                     <input type="checkbox" id="cbDisplayCircle" name="cbDisplayCircle" data-mini="true"/>
 
                     <label for="changeCircleRadius" class="ui-hidden-accessible">円表示</label>
@@ -87,10 +104,11 @@
                     <!--
                     <a id="btnHelp" href="#helpDialog" data-rel="popup" data-position-to="window" class="ui-btn ui-icon-question ui-btn-icon-notext">help</a>
                     -->
+                  </li>
+                </ul>
                 </fieldset>
             </div>
-            <div id="map" class="map">
-            </div>
+
             <div id="popup" data-role="popup" data-theme="a" class="ui-content ol-popup" style="max-height: 200px;">
                 <a href="#" id="popup-closer" data-rel="back" class="ui-btn ui-corner-all ui-shadow ui-btn-a ui-icon-delete ui-btn-icon-notext ui-btn-right">Close</a>
                 <div id="popup-title" data-role="header" data-theme="a"></div>
@@ -100,8 +118,8 @@
         <div data-role="popup" data-history="false" id="filterdialog" data-theme="a" class="ui-corner-all ui-icon-delete ui-btn-left">
             <a href="#" data-rel="back" class="ui-btn ui-corner-all ui-shadow ui-btn-a ui-icon-delete ui-btn-icon-notext ui-btn-right">Close</a>
             <form>
-                <div style="padding:10px 20px;">
-                    <h3>保育施設 絞り込み</h3>
+                <div style="padding:3px 10px;">
+                    <h4><b>保育施設 絞り込み</b></h4>
 
                     <legend>公立認可保育園</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -120,10 +138,6 @@
                         <label for="pubNinkaEncho">延長保育</label>
                         <input type="checkbox" id="pubNinkaEncho" class="filtercb">
                     </fieldset>
-                    <!-- <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="pubNinkaVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
-                        <input type="checkbox" id="pubNinkaVacancy" class="filtercb">
-                    </fieldset> -->
 
                     <legend>私立認可保育園</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -142,10 +156,6 @@
                         <label for="priNinkaEncho">延長保育</label>
                         <input type="checkbox" id="priNinkaEncho" class="filtercb">
                     </fieldset>
-                    <!-- <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="priNinkaVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
-                        <input type="checkbox" id="priNinkaVacancy" class="filtercb">
-                    </fieldset> -->
 
                     <legend>横浜保育室</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -164,10 +174,6 @@
                         <label for="yhoikuEncho">延長保育</label>
                         <input type="checkbox" id="yhoikuEncho" class="filtercb">
                     </fieldset>
-                    <!-- <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="yhoikuVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
-                        <input type="checkbox" id="yhoikuVacancy" class="filtercb">
-                    </fieldset> -->
 
                     <legend>認可外保育園</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -186,16 +192,7 @@
                         <label for="ninkagaiEncho">延長保育</label>
                         <input type="checkbox" id="ninkagaiEncho" class="filtercb">
                     </fieldset>
-                    <!-- <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="ninkagaiVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
-                        <input type="checkbox" id="ninkagaiVacancy" class="filtercb">
-                    </fieldset> -->
-                    <!-- //2017-02 kakiki-del
-                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                    <label for="ninkagaiShomei">証明書あり</label>
-                    <input type="checkbox" id="ninkagaiShomei" class="filtercb">
-                    </fieldset>
-                    -->
+
                     <legend>幼稚園</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="kindergartenOpenTime" class="select">開園</label>
@@ -213,10 +210,6 @@
                         <label for="kindergartenEncho">延長保育</label>
                         <input type="checkbox" id="kindergartenEncho" class="filtercb">
                     </fieldset>
-                    <!-- <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="kindergartenVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
-                        <input type="checkbox" id="kindergartenVacancy" class="filtercb">
-                    </fieldset> -->
 
                     <legend>小規模・事業所内保育事業</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -235,10 +228,6 @@
                         <label for="jigyoshoEncho">延長保育</label>
                         <input type="checkbox" id="jigyoshoEncho" class="filtercb">
                     </fieldset>
-                    <!-- <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="jigyoshoVacancy">空きあり（試用版。最新の空き状況ではありません）</label>
-                        <input type="checkbox" id="jigyoshoVacancy" class="filtercb">
-                    </fieldset> -->
 
                     <legend>障害児通所支援事業</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
@@ -258,35 +247,20 @@
                         <input type="checkbox" id="disabilityEncho" class="filtercb">
                     </fieldset>
 
+                    <div style="padding:1px"></div>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <a href="#" data-rel="back" id="filterApply" class="ui-btn ui-corner-all ui-btn-a ui-btn-icon-left ui-icon-check">条件適用</a>
                         <a href="#" id="filterReset" class="ui-btn ui-corner-all ui-btn-a ui-btn-icon-left ui-icon-delete">リセット</a>
-                        <label for="filteredList">検索結果の一覧を表示</label>
+                        <label for="filteredList">検索結果一覧を表示</label>
                         <input type="checkbox" id="filteredList">
                     </fieldset>
                 </div>
             </form>
         </div>
-        <!---
-        <div data-role="popup" data-history="false" id="helpDialog" data-theme="a" class="ui-corner-all ui-icon-delete ui-btn-left">
-            <a href="#" data-rel="back" class="ui-btn ui-corner-all ui-shadow ui-btn-a ui-icon-delete ui-btn-icon-notext ui-btn-right">Close</a>
-            <div style="padding:10px 20px;">
-                <h3>さっぽろ保育園マップ</h3>
-                <fieldset>
-                    <p>
-                    v1.0 (rev.20141130)
-                    </p>
-                    <a href="http://www.codeforsapporo.org/papamama/" target="_blank">詳しくはこちら</a>
-                </fieldset>
-                <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                    <p>
-                    (C) 2014 <a href="http://www.codeforsapporo.org/" target="_blank">Code for Sapporo.</a>
-                    </p>
-                    <a href="#" data-rel="back" id="helpClose" class="ui-btn ui-corner-all ui-btn-a ui-btn-icon-left ui-icon-check">閉じる</a>
-                </fieldset>
-            </div>
+
+        <div  id="map-logo">
+          <h5 style="background-color: rgba(255,255,255,0.8); padding: 2px 0 0 2px"><font size="1"> Codefor港北</font> 保育園/幼稚園マップ</h5>
         </div>
-        -->
         </div>
         <script src="js/jquery-2.1.1.min.js" type="text/javascript"></script>
         <script src="js/jquery.mobile-1.4.4.min.js" type="text/javascript"></script>

--- a/js/index.js
+++ b/js/index.js
@@ -76,13 +76,15 @@ var mapServerList = {
  * デバイス回転時、地図の大きさを画面全体に広げる
  * @return {[type]} [description]
  */
-function resizeMapDiv() {
-	var screenHeight = $.mobile.getScreenHeight();
-	var contentCurrentHeight = $(".ui-content").outerHeight() - $(".ui-content").height();
-	var contentHeight = screenHeight - contentCurrentHeight;
-	var navHeight = $("#nav1").outerHeight();
-	$(".ui-content").height(contentHeight);
-	$("#map").height(contentHeight - navHeight);
+ function resizeMapDiv() {
+ 	var screenHeight = $.mobile.getScreenHeight();
+ 	// var contentCurrentHeight = $(".ui-content").outerHeight() - $(".ui-content").height();
+ 	// var contentHeight = screenHeight - contentCurrentHeight;
+ 	// var navHeight = $("#nav1").outerHeight();
+ 	// $(".ui-content").height(contentHeight);
+ 	$(".ui-content").height(screenHeight);
+ 	$("#map").height(screenHeight);
+ 	// $("#map").height(contentHeight - navHeight);
 }
 
 $(window).on("orientationchange", function() {
@@ -360,7 +362,7 @@ $('#mainPage').on('pageshow', function() {
 		$('.filtercb').each(function(index,item ) {
 			if (item.checked) conditions[item .id] = 'Y';
 	  });
-				
+
 		// フィルター適用時
 		if(Object.keys(conditions).length > 0) {
 			var filter = new FacilityFilter();
@@ -527,6 +529,74 @@ $('#mainPage').on('pageshow', function() {
 		 $('#markerTitle').hide();
 		 $('#marker').hide();
 	 }
+
+	  // メニューボタンをクリックした時のイベントの登録
+		document.getElementById('nav1-btn').addEventListener('click', function (event) {
+	 	 	var elem = document.getElementsByClassName("nav1-li");
+			if (elem[0].style.display === "none") {
+				Object.keys(elem[0].children).forEach(function(i){
+					elem[0].children[i].style.width =  (window.innerWidth / 3 * 1) + "px";
+				});
+				["btnFilter", "changeBaseMap-button", "moveTo-button", "changeCircleRadius-button", "btnHelp"].forEach(function(e) {
+					document.getElementById(e).style.width = (window.innerWidth / 3 * 1) + "px";
+				});
+				elem[0].style.display ="inline-block";
+				document.getElementById("nav1").style.top = (this.clientHeight + 10) + "px";
+				document.getElementById("nav1").style.left = (window.innerWidth / 3 * 2 - 5) + "px";
+				elem[1].style.display ="inline-block";
+			} else {
+				elem[0].style.display ="none";
+				elem[1].style.display ="none";
+			}
+
+ 	 });
+
+   // メニューバーとロゴをWindowサイズに合わせて配置を変更する
+	 var toggleNavbar = function () {
+		 	var elem = document.getElementsByClassName("nav1-li");
+			document.getElementById("nav1").style.top = "0px";
+			document.getElementById("nav1").style.left = "50px";
+			Object.keys(elem[0].children).forEach(function(item){
+				elem[0].children[item].style.width = "";
+			});
+			["btnFilter", "changeBaseMap-button", "moveTo-button", "changeCircleRadius-button", "btnHelp"].forEach(function(e) {
+				document.getElementById(e).style.width = "";
+			});
+		 	elem[0].style.display ="inline-block";
+			elem[1].style.display ="inline-block";
+			var btn = document.getElementById("nav1-btn-div");
+			btn.style.display = "none";
+
+			var logo = document.getElementById("map-logo");
+			logo.style.left = window.innerWidth / 2 - 115 + "px";
+			// Windowサイズがメニューの幅より小さい場合(つまりメニューが複数行となる場合)
+		 	if (elem[0].clientHeight > 50) {
+		 		elem[0].style.display ="none";
+				elem[1].style.display ="none";
+				btn.style.display = "block";
+				logo.style.top = "0";
+				logo.style.bottom = "";
+			// Windowサイズがメニューの幅より大きい場合
+		 	} else {
+		 		elem[0].style.display ="inline-block";
+				elem[1].style.display ="inline-block";
+				btn.style.display = "none";
+				logo.style.top = "";
+				logo.style.bottom = "0";
+		 	}
+	 };
+	 // ページのロード時に一度実行する
+	 toggleNavbar();
+
+	 // Windowsサイズの変更時のイベントを登録
+	 var resizeTimer;
+	 window.addEventListener('resize', function (event) {
+	 	if (resizeTimer !== false) {
+	 		clearTimeout(resizeTimer);
+	 	}
+	 	resizeTimer = setTimeout(toggleNavbar(), 100);
+	 });
+
 });
 
 /**


### PR DESCRIPTION
@toon258 @chikarina @hatanakayumiko
※見た目に大きな変更がありますのでマージ後にレビューいただきたい内容です。
　マージ後に元に戻す、または修正を加えるで大丈夫です。

＜プルリクエストの内容＞
基本的にはユーザビリティを高める(マップを見やすくする)ためです。
ただUDCでもcodoForSapporoと違いがあるほうがアピールしがいがあるかもしれません笑

・メニュー一覧とマップロゴをマップの上から、マップ上に移動しました。

・メニューバーはブラウザの幅によって2段階の変化をします。
　「中」のボタンまで一行で表示できない幅になると右上に１つのメニューボタンだけが表示され、ボタンを押すことでメニューバーの項目が表示されます。

・マップロゴを小さしてブラウザ幅がある時は画面下の中央に、メニューがボタン１つに代わると画面上中央に移動します。これは画面幅が小さくなると画面下では距離の尺度などマップ上のアイテムと重なるためです。
