### PR TITLE
検索でfilteredList.htmlを開く際のパス指定を相対パスへ変更

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -377,8 +377,7 @@ $('#mainPage').on('pageshow', function() {
 					urlQuery += item + '=' + conditions[item] + '&';
 				});
 				urlQuery = urlQuery.slice(0,urlQuery.length-1);
-				var urlpath = (location.pathname === '/') ? '/' : location.pathname + '/';
-				window.open(location.origin+urlpath+'filteredList.html'+urlQuery);
+				window.open('filteredList.html'+urlQuery);
 			}
 		} else {
 			papamamap.addNurseryFacilitiesLayer(nurseryFacilities);


### PR DESCRIPTION
もともとの以下ではlocation.pathnameにindex.htmlが含まれていた場合404エラーのため修正

var urlpath = (location.pathname === '/') ? '/' : location.pathname + '/';
window.open(location.origin+urlpath+'filteredList.html'+urlQuery);