### PR TITLE
新設園ボタン、検索ボタンに新設園を条件指定と検索結果一覧表示へ対応

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -52,7 +52,7 @@
 }
 
 #nav1-btn, #lblPubNinka, #lblPriNinka, #lblNinkagai, #lblYhoiku, #lblJigyosho, #lblKindergarten, #lblDisability, #lblGakudou, #lblElementarySchool, #lblMiddleSchool,
-#btnFilter, #changeBaseMap-button, #moveTo-button, #changeCircleRadius-button, #btnHelp {
+#btnFilter, #btnNewSchool, #changeBaseMap-button, #moveTo-button, #changeCircleRadius-button, #btnHelp {
 	border: groove white;
 	border-radius: 5px 5px 5px 5px / 5px 5px 5px 5px;
 }
@@ -135,6 +135,13 @@
 }
 #lblGakudou:hover {
 	color: lightblue;
+}
+
+#divNameKeyword {
+	float: left;
+}
+#divNewSchool {
+	float: right;
 }
 
 #lblElementarySchool.ui-checkbox-on {

--- a/index.html
+++ b/index.html
@@ -74,7 +74,12 @@
                        検索
                     </a>
 
-                    <select id="changeBaseMap" >
+                    <a id="btnNewSchool" 
+                        class="ui-btn ui-corner-all ui-btn-a ui-icon-filter ui-btn-icon-right ui-icon-check">
+                        新設園
+                    </a>
+
+                    <select id="changeBaseMap">
                         <option>背景</option>
                     </select>
 
@@ -112,13 +117,26 @@
             <form>
                 <div style="padding:3px 10px;">
                     <h4><b>保育施設 絞り込み</b></h4>
-                    
-                    <legend>施設名キーワード</legend>
-                    <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
-                        <label for="nameKeyword">施設名キーワード</label>
-                        <input type="text" id="nameKeyword">
-                    </fieldset>
 
+                    <div>
+                        <div id=divNewSchool>
+                            <legend>　</legend>
+                            <div style="padding:3px;"></div>
+                            <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
+                                <label for="newSchool">新設園</label>
+                                <input type="checkbox" id="newSchool">
+                            </fieldset>
+                        </div>
+                        <div id=divNameKeyword>
+                            <legend>施設名キーワード</legend>
+                            <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
+                                <label for="nameKeyword">施設名キーワード</label>
+                                <input type="text" id="nameKeyword">
+                            </fieldset>
+                        </div>
+                    </div>
+
+                    <div style="padding:40px;"></div>
                     <legend>公立認可保育園</legend>
                     <fieldset data-role="controlgroup" data-type="horizontal" data-mini="true">
                         <label for="pubNinkaOpenTime" class="select">開園</label>

--- a/js/filteredList.js
+++ b/js/filteredList.js
@@ -25,9 +25,11 @@ if(location.search) {
          });
      });
   var nameKeyword = decodeURI(conditions.nameKeyword);
-  nameKeyword = nameKeyword !== "null" ? nameKeyword : ""
+  nameKeyword = nameKeyword !== "null" ? nameKeyword : "";
+  var newSchool = decodeURI(conditions.newSchool) !== "false" ? true : false;
   delete conditions.nameKeyword;
-
+  delete conditions.newSchool;
+  
   var checkObj = {};
   Object.keys(facilityObj).forEach(function(elem){
     checkObj[elem] = false;
@@ -133,9 +135,9 @@ function createFilteredList () {
 
   var filter = new FacilityFilter();
   ga_label = 0; // 定義のみで使用されない
-  console.log(nameKeyword);
+  
   var features = filter.getFilteredFeaturesGeoJson( // checkObjを参照渡しで表示レイヤーを取得する
-        {nameKeyword, conditions, checkObj, ga_label},
+        {newSchool, nameKeyword, conditions, checkObj, ga_label},
         nurseryFacilities
   ).features;
 
@@ -182,6 +184,7 @@ function createFilterText() {
   filterCondition.appendChild(document.createElement('br'));
 
   if(nameKeyword) textObj = Object.assign({"施設名キーワード": nameKeyword}, textObj);
+  if(newSchool) textObj = Object.assign({"新規園": "適用"}, textObj);
   Object.keys(textObj).forEach(function(type){    // " - 施設名 (条件)"のテキスト生成
     var elem_span = document.createElement('span');
     elem_span.textContent = ' - ' + type + ' (' + textObj[type] + ')';

--- a/js/handlers.js
+++ b/js/handlers.js
@@ -104,7 +104,7 @@ function toggleNavbar() {
     Object.keys(elem[0].children).forEach(function(item){
         elem[0].children[item].style.width = "";
     });
-    ["btnFilter", "changeBaseMap-button", "moveTo-button", "changeCircleRadius-button", "btnHelp"].forEach(function(evt) {
+    ["btnFilter", "btnNewSchool", "changeBaseMap-button", "moveTo-button", "changeCircleRadius-button", "btnHelp"].forEach(function(evt) {
         document.getElementById(evt).style.width = "";
     });
 
@@ -129,7 +129,7 @@ function toggleNavbar() {
         Object.keys(elem[0].children).forEach(function(i){
             elem[0].children[i].style.width =  (window.innerWidth / 3 * 1) + "px";
         });
-        ["btnFilter", "changeBaseMap-button", "moveTo-button", "changeCircleRadius-button", "btnHelp"].forEach(function(e) {
+        ["btnFilter", "btnNewSchool", "changeBaseMap-button", "moveTo-button", "changeCircleRadius-button", "btnHelp"].forEach(function(e) {
             document.getElementById(e).style.width = (window.innerWidth / 3 * 1) + "px";
         });
 

--- a/js/papamamap.js
+++ b/js/papamamap.js
@@ -421,7 +421,7 @@ Papamamap.prototype.getPopupContent = function(feature)
     if (!isUndefined(foundation)) {
         contentFactory.addContent({
             th: '設立年度',
-            td: foundation
+            td: foundation + '年'
         });
         // var foundation_year = foundation.substring(0, 4);
         // var current_date = new Date();


### PR DESCRIPTION
＜追加機能＞
・メニューに新設園ボタン追加
・メニューの検索ボタンからの絞り込み条件として新設園ボタン追加
・メニューの検索ボタンの検索結果一覧表示に新設園も対応


＜追加機能の仕様＞
・新設園ボタンと検索ボタンは独立排他的に動作。
   -> 新設園ボタンで絞り込み状態で検索ボタンを実行すると
        新設園ボタンの絞り込みはクリアされる。逆もまた同様。
・検索ボタン内では新設園も他条件と同様に絞り込みは論理積(AND)検索。
・新設園の絞り込みは施設名(Name)が「新設・仮称」の文字列を含むこと。
・検索ボタン内で同時に施設名キーワード検索も入力した場合、
　「新設・仮称」とキーワード検索で指定した文字列のAND検索。


＜補足＞
・上述の通り、新設園の絞り込みは施設名の文字列検索のため、
　新設園の対象とする施設の更新は、スプレッドシートの元データの手動更新となる。

・不採用とした代替案として新設園の絞り込み方法としては以下 (コード上はコメントアウト)。
    プロパティ「設立年度」の値により以下の２つの場合に新設園と判定
      -> 値が翌年
　　　※例、今が2019年なら2020で新設園とみなす
      -> 値が今年だが、現在日時が上半期
　　　※例、仮に今が2019年6月なら設立年度が2019なら新設園とみなす
　上記判定方法は新規園の追加が年始から年度初めのみの想定となり、
　設立前後しばらくの期間、新設園の対象となる。

　問題点として下半期に追加の場合で対象外となってしまう、
　また意図的に新設園の対象/対象外を調整したい場合に不便。
　そもそも仕組みがややこしいので不採用。
　 